### PR TITLE
Fix: actualized documentation url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and use them when selecting an ssh connection.
 ![GitHub issues](https://img.shields.io/github/issues/ssh-connection-manager/ssh-)
 
 ## Documentation
-User [documentation](https://ssh-connection-manager.github.io/docs/) is available at.
+User [documentation](https://misha-ssh.github.io/docs/) is available at.
 
 ## Installation
 


### PR DESCRIPTION
Linked issue https://github.com/misha-ssh/cli/issues/174
![mqdefault](https://github.com/user-attachments/assets/4dca1307-aaf5-4e08-a496-8151bd83304c)
